### PR TITLE
Fix exclude and post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ description: A collection of posts from Drs. Clark and Moore and their students.
 show_excerpts: false
 
 theme: minima
+
+exclude: [post-template.md]

--- a/_posts/2018-10-08-how-to-write-a-post.md
+++ b/_posts/2018-10-08-how-to-write-a-post.md
@@ -57,6 +57,23 @@ You have a few key things to remember:
 
 After you submit your post via a pull request, it will be reviewed and you might be asked to fix grammar or some of your text. This will be done using the [GitHub pull request functionality](https://help.github.com/articles/about-pull requests/) (see also [Creating a Pull Request](https://help.github.com/articles/creating-a-pull-request/)).
 
+Once the review process is complete, you should delete the git branch you created to make your post.
+
+# Updating your local repository
+
+If you want to update your local repository (for example, to prepare to submit a new post), you should following these steps, which assume that you used the process above to clone and fork the repository.
+
+```bash
+# Fetch the updated files from the compusciencing repository
+git fetch origin/master
+
+# Checkout your local master branch and merge the origin files
+git checkout master
+git merge origin/master
+
+# Create a new branch (as described above) to create a new post
+```
+
 # Resources
 
 - [Jekyll Documentation on Posts](https://jekyllrb.com/docs/posts/)

--- a/index.md
+++ b/index.md
@@ -1,3 +1,4 @@
-[Anthony J. Clark](http://anthonyjclark.com/)
+This set of posts is a dumping ground for Dr. [Jared M. Moore](http://jaredmmoore.com/) at [Grand Valley State University](https://www.gvsu.edu) and Dr. [Anthony J. Clark](http://anthonyjclark.com/) at [Missouri State University](http://missouristate.edu). It contains relatively short posts detailing scripts, ideas, etc. that we don't want to forget. It will also contain student reports for semester projects and research projects.
 
-[Jared M. Moore](http://jaredmmoore.com/)
+---
+


### PR DESCRIPTION
This PR adds a brief introduction, hides the template file from Jekyll, and adds a bit more information to the first post.